### PR TITLE
KETTLE-45: Fixed implementation of "gradeNames" support for request handlers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 npm-debug.log
+.project
 
 /node_modules

--- a/docs/RequestHandlersAndApps.md
+++ b/docs/RequestHandlersAndApps.md
@@ -43,13 +43,18 @@ multiple apps are merged together from different sources to produce combined app
         <tr>
             <td><code>type</code></td>
             <td><code>String</code></td>
-            <td>The name of a request handling grade, which must be descended from <code>kettle.request</code>. If you supply the <code>method</code> field, your grade must be descended from <code>kettle.request.http</code></td>
+            <td>The name of a request handling grade, which must be descended from <code>kettle.request</code>. If you supply the <code>method</code> field, your grade must be descended from <code>kettle.request.http</code>.</td>
         </tr>
         <tr>
             <td><code>route</code></td>
             <td><code>String</code></td>
             <td>An express-compatible <a href="http://expressjs.com/guide/routing.html">routing</a> string, expressing the range of HTTP paths to be handled by this handler, together with any named parameters and query parameters
-            that should be captured. The exact syntax for route matching is documented more precisely at <a href="https://github.com/pillarjs/path-to-regexp">pillarjs</a></td>
+            that should be captured. The exact syntax for route matching is documented more precisely at <a href="https://github.com/pillarjs/path-to-regexp">pillarjs</a>.</td>
+        </tr>
+        <tr>
+            <td><code>gradeNames</code> (optional)</td>
+            <td><code>String/Array of String</code></td>
+            <td>One or more grade names which will be mixed in to the constructed handler when it is constructed.</td>
         </tr>
         <tr>
             <td><code>prefix</code> (optional)</td>
@@ -59,14 +64,13 @@ multiple apps are merged together from different sources to produce combined app
             this is the same behaviour as express.js <a href="http://expressjs.com/api.html#app.use">routing system</a>. It is primarily useful when using <a href="#thing">static middleware</a> which will compare the
             <code>req.url</code> value with the filesystem path relative to its mount point.
         </tr>
-        
         <tr>
             <td><code>method</code> (optional)</td>
             <td><code>String</code> value – one of the valid <a href="https://github.com/nodejs/node/blob/master/deps/http_parser/http_parser.h#L88">HTTP methods</a> supported by node.js, expressed in lower case, or else a comma-separated 
             sequence of such values.
             </td>
             <td>The HTTP request type(s) which this handler will match. <code>method</code> is omitted in the 
-            case that the request handling grade is not descended from <code>kettle.request.http</code> – the only currently supported requests of that type are WebSockets requests descended from <code>kettle.request.ws</code> 
+            case that the request handling grade is not descended from <code>kettle.request.http</code> – the only currently supported requests of that type are WebSockets requests descended from <code>kettle.request.ws</code>.
         </tr>
     </tbody>
 </table>

--- a/lib/KettleServer.js
+++ b/lib/KettleServer.js
@@ -132,7 +132,7 @@ kettle.server.evaluateRoute = function (server, req, originOptions) {
             fluid.fail("Error in Kettle application definition - handler ", fluid.censorKeys(handler, ["app"]), " must have a request grade name registered as member \"type\"");
         }
         fluid.log("Invoking handler " + handler.type + " for route " + handler.route + " with expectedGrade " + originOptions.expectedRequestGrade);
-        var defaults = fluid.defaults(handler.type, handler.gradeNames);
+        var defaults = fluid.getMergedDefaults(handler.type, handler.gradeNames);
         if (!fluid.hasGrade(defaults, "kettle.request")) {
             fluid.fail("Error in Kettle application definition - couldn't load handler " + handler.type + " and gradeNames " +
                 JSON.stringify(fluid.makeArray(handler.gradeNames)) + " to a component derived from kettle.request - got defaults of " + JSON.stringify(defaults));

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "kettle",
     "description": "Declarative IoC-based framework for HTTP and WebSockets servers on node.js based on express and ws",
-    "version": "1.0.1",
+    "version": "1.1.0",
     "author": {
         "name": "The Fluid Project"
     },
@@ -13,17 +13,17 @@
     },
     "homepage": "http://wiki.fluidproject.org/display/fluid/Kettle",
     "dependencies": {
-        "express": "4.13.3",
-        "body-parser": "1.13.3",
-        "cookie-parser": "1.3.5",
-        "express-session": "1.11.3",
-        "serve-static": "1.10.0",
-        "ws": "0.8.0",
+        "express": "4.14.0",
+        "body-parser": "1.15.2",
+        "cookie-parser": "1.4.3",
+        "express-session": "1.14.0",
+        "serve-static": "1.11.1",
+        "ws": "1.1.1",
         "infusion": "2.0.0-dev.20160519T222603Z.754d2c6",
         "jsonlint": "1.6.0",
         "resolve": "1.1.6",
-        "node-uuid": "1.4.0",
-        "path-to-regexp": "0.1.7"
+        "node-uuid": "1.4.7",
+        "path-to-regexp": "1.5.3"
     },
     "devDependencies": {
         "fluid-grunt-eslint": "18.1.1",

--- a/tests/GoodRequestTests.js
+++ b/tests/GoodRequestTests.js
@@ -156,11 +156,43 @@ fluid.defaults("kettle.tests.goodRequest.mismatchRoute.config", {
     }
 });
 
+/* KETTLE-45 handler with gradeNames support */
+
+fluid.defaults("kettle.tests.goodRequest.gradeNames.config", {
+    handler: {
+        type: "kettle.tests.goodRequest.gradeNames.handler",
+        gradeNames: "kettle.tests.goodRequest.gradeNames.mixin",
+        method: "get"
+    },
+    name: "Good request: gradeNames for handler",
+    message: "Received response from handler with gradeNames",
+    expected: {message: "Fetched from derived grade"}
+});
+
+fluid.defaults("kettle.tests.goodRequest.gradeNames.handler", {
+    gradeNames: "kettle.request.http",
+    invokers: {
+        handleRequest: {
+            funcName: "kettle.tests.goodRequest.gradeNames.handleRequest"
+        }
+    }
+});
+
+fluid.defaults("kettle.tests.goodRequest.gradeNames.mixin", {
+    gradeNames: "fluid.component",
+    mixinValue: "Fetched from derived grade"
+});
+
+kettle.tests.goodRequest.gradeNames.handleRequest = function (request) {
+    request.events.onSuccess.fire({message: request.options.mixinValue});
+};
+
 kettle.tests.goodRequest.testDefs = [
     "kettle.tests.goodRequest.emptyParameter.config",
     "kettle.tests.goodRequest.doubleResponse.config",
     "kettle.tests.goodRequest.options.config",
-    "kettle.tests.goodRequest.mismatchRoute.config"
+    "kettle.tests.goodRequest.mismatchRoute.config",
+    "kettle.tests.goodRequest.gradeNames.config"
 ];
 
 kettle.tests.singleRequest.executeTests(kettle.tests.goodRequest.testDefs, "kettle.tests.goodRequest.testDefTemplate");


### PR DESCRIPTION
and documented. Bumped to the latest version of all dependencies.