### PR TITLE
GPII-1872: Split the implementatino of kettle.dataSource.URL into its own file

### DIFF
--- a/kettle.js
+++ b/kettle.js
@@ -19,7 +19,8 @@ require("./lib/KettleUtils.js");
 fluid.module.register("kettle", __dirname, require);
 
 require("./lib/dataSource-core.js");
-require("./lib/dataSource-node.js");
+require("./lib/dataSource-file.js");
+require("./lib/dataSource-url.js");
 require("./lib/KettleApp.js");
 require("./lib/KettleConfigLoader.js");
 require("./lib/KettleMiddleware.js");

--- a/lib/KettleRequest.js
+++ b/lib/KettleRequest.js
@@ -12,7 +12,7 @@
 
 "use strict";
 
-var fluid = require("infusion"),
+var fluid = fluid || require("infusion"),
     kettle = fluid.registerNamespace("kettle");
 
 fluid.defaults("kettle.requests", {

--- a/lib/dataSource-file.js
+++ b/lib/dataSource-file.js
@@ -1,0 +1,106 @@
+/*!
+Kettle File DataSource
+
+Copyright 2012-2013 OCAD University
+Copyright 2016 OCAD University
+
+Licensed under the New BSD license. You may not use this file except in
+compliance with this License.
+
+You may obtain a copy of the License at
+https://github.com/fluid-project/kettle/blob/master/LICENSE.txt
+*/
+
+"use strict";
+
+var fluid = fluid || require("infusion"),
+    kettle = fluid.registerNamespace("kettle"),
+    fs = require("fs");
+
+fluid.require("querystring", require, "node.querystring");
+
+fluid.registerNamespace("kettle.dataSource");
+
+/**** FILE DATASOURCE SUPPORT ****/
+
+fluid.defaults("kettle.dataSource.file", {
+    gradeNames: ["kettle.dataSource"],
+    readOnlyGrade: "kettle.dataSource.file",
+    invokers: {
+        getImpl: {
+            funcName: "kettle.dataSource.file.handle",
+            args: ["{that}", "{arguments}.0", "{arguments}.1"] // options, directModel
+        }
+    }
+});
+
+fluid.defaults("kettle.dataSource.file.writable", {
+    gradeNames: ["kettle.dataSource.writable"],
+    invokers: {
+        setImpl: {
+            funcName: "kettle.dataSource.file.handle",
+            args: ["{that}", "{arguments}.0", "{arguments}.1", "{arguments}.2"] // options, directModel, model
+        }
+    }
+});
+
+/** Central strategy point for all file-system backed DataSource operations (both read and write).
+ * Accumulates options to be sent to the underlying node.js `readFile` or `writeFile` primitives, collects and interprets the
+ * results back into promise resolutions.
+ * @param that {Component} The DataSource itself
+ * @param requestOptions {Object} A merged form of the options sent to the top-level `dataSource.get` method together with relevant
+ * static options configured on the component
+ * @param directModel {Object} The `directModel` argument sent to top-level `dataSource.get/set`
+ * @param model {String} The `model` argument sent to top-level `dataSource.get/set` after it has been pushed through the transform chain
+ */
+
+kettle.dataSource.file.handle = function (that, requestOptions, directModel, model) {
+    if (!that.options.path) {
+        fluid.fail("Cannot operate file dataSource ", that, " without an option named \"path\"");
+    }
+    var fileName = kettle.dataSource.URL.resolveUrl(that.options.path, that.options.termMap, directModel, true);
+    var promise = fluid.promise(),
+        method = "readFile",
+        operation = requestOptions.operation,
+        fsCallback = function (error, readData) {
+            /* istanbul ignore if - don't know how to reliably and portably trigger file error that is not "not found" */
+            if (error) {
+                promise.reject({
+                    message: error.message
+                });
+            } else {
+                promise.resolve(requestOptions.operation === "set" ? undefined : readData);
+            }
+        },
+        args = [fileName, that.options.charEncoding];
+    promise.accumulateRejectionReason = function (originError) {
+        return kettle.upgradeError(originError, " while " + (operation === "set" ? "writing" : "reading") + " file " + fileName);
+    };
+    if (operation === "set") {
+        method = "writeFile";
+        args.splice(1, 0, model);
+    } else {
+        if (!fs.existsSync(fileName)) {
+            if (requestOptions.notFoundIsEmpty) {
+                promise.resolve(undefined);
+            } else {
+                promise.reject({
+                    isError: true,
+                    message: "File " + fileName + " was not found",
+                    statusCode: 404
+                });
+            }
+            return promise;
+        }
+    }
+    args.push(kettle.wrapCallback(fsCallback));
+    fs[method].apply(null, args);
+    return promise;
+};
+
+/** A mixin grade for `kettle.dataSource.file` which automatically expands any %terms corresponding to module names registered in Infusion's module database */
+
+fluid.defaults("kettle.dataSource.file.moduleTerms", {
+    gradeNames: "kettle.dataSource.file",
+    termMap: "@expand:fluid.module.terms()"
+});

--- a/lib/dataSource-url.js
+++ b/lib/dataSource-url.js
@@ -1,7 +1,8 @@
 /*!
-Kettle DataSource
+Kettle File DataSource
 
 Copyright 2012-2013 OCAD University
+Copyright 2016 OCAD University
 
 Licensed under the New BSD license. You may not use this file except in
 compliance with this License.
@@ -12,101 +13,13 @@ https://github.com/fluid-project/kettle/blob/master/LICENSE.txt
 
 "use strict";
 
-var fluid = require("infusion"),
+var fluid = fluid || require("infusion"),
     kettle = fluid.registerNamespace("kettle"),
-    fs = require("fs"),
-    http = require("http"),
-    https = require("https"),
-    urlModule = require("url");
-
-fluid.require("querystring", require, "node.querystring");
+    http = http || require("http"),
+    https = https || require("https"),
+    urlModule = urlModule || require("url");
 
 fluid.registerNamespace("kettle.dataSource");
-
-/**** FILE DATASOURCE SUPPORT ****/
-
-fluid.defaults("kettle.dataSource.file", {
-    gradeNames: ["kettle.dataSource"],
-    readOnlyGrade: "kettle.dataSource.file",
-    invokers: {
-        getImpl: {
-            funcName: "kettle.dataSource.file.handle",
-            args: ["{that}", "{arguments}.0", "{arguments}.1"] // options, directModel
-        }
-    }
-});
-
-fluid.defaults("kettle.dataSource.file.writable", {
-    gradeNames: ["kettle.dataSource.writable"],
-    invokers: {
-        setImpl: {
-            funcName: "kettle.dataSource.file.handle",
-            args: ["{that}", "{arguments}.0", "{arguments}.1", "{arguments}.2"] // options, directModel, model
-        }
-    }
-});
-
-/** Central strategy point for all file-system backed DataSource operations (both read and write).
- * Accumulates options to be sent to the underlying node.js `readFile` or `writeFile` primitives, collects and interprets the
- * results back into promise resolutions.
- * @param that {Component} The DataSource itself
- * @param requestOptions {Object} A merged form of the options sent to the top-level `dataSource.get` method together with relevant
- * static options configured on the component
- * @param directModel {Object} The `directModel` argument sent to top-level `dataSource.get/set`
- * @param model {String} The `model` argument sent to top-level `dataSource.get/set` after it has been pushed through the transform chain
- */
-
-kettle.dataSource.file.handle = function (that, requestOptions, directModel, model) {
-    if (!that.options.path) {
-        fluid.fail("Cannot operate file dataSource ", that, " without an option named \"path\"");
-    }
-    var fileName = kettle.dataSource.URL.resolveUrl(that.options.path, that.options.termMap, directModel, true);
-    var promise = fluid.promise(),
-        method = "readFile",
-        operation = requestOptions.operation,
-        fsCallback = function (error, readData) {
-            /* istanbul ignore if - don't know how to reliably and portably trigger file error that is not "not found" */
-            if (error) {
-                promise.reject({
-                    message: error.message
-                });
-            } else {
-                promise.resolve(requestOptions.operation === "set" ? undefined : readData);
-            }
-        },
-        args = [fileName, that.options.charEncoding];
-    promise.accumulateRejectionReason = function (originError) {
-        return kettle.upgradeError(originError, " while " + (operation === "set" ? "writing" : "reading") + " file " + fileName);
-    };
-    if (operation === "set") {
-        method = "writeFile";
-        args.splice(1, 0, model);
-    } else {
-        if (!fs.existsSync(fileName)) {
-            if (requestOptions.notFoundIsEmpty) {
-                promise.resolve(undefined);
-            } else {
-                promise.reject({
-                    isError: true,
-                    message: "File " + fileName + " was not found",
-                    statusCode: 404
-                });
-            }
-            return promise;
-        }
-    }
-    args.push(kettle.wrapCallback(fsCallback));
-    fs[method].apply(null, args);
-    return promise;
-};
-
-/** A mixin grade for `kettle.dataSource.file` which automatically expands any %terms corresponding to module names registered in Infusion's module database */
-
-fluid.defaults("kettle.dataSource.file.moduleTerms", {
-    gradeNames: "kettle.dataSource.file",
-    termMap: "@expand:fluid.module.terms()"
-});
-
 
 /**** URL DATASOURCE SUPPORT ****/
 


### PR DESCRIPTION
To make easier to use this data source in-browser, with browserifying necessary node module dependencies.