### PR TITLE
Update uuid to version 3.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,60 +1,60 @@
 {
-    "name": "kettle",
-    "description": "Declarative IoC-based framework for HTTP and WebSockets servers on node.js based on express and ws",
-    "version": "1.2.1",
-    "author": {
-        "name": "The Fluid Project"
-    },
-    "bugs": {
-        "url": "http://issues.fluidproject.org/browse/KETTLE"
-    },
-    "scripts": {
-        "test": "node tests/all-tests.js"
-    },
-    "homepage": "http://wiki.fluidproject.org/display/fluid/Kettle",
-    "dependencies": {
-        "express": "4.14.0",
-        "body-parser": "1.15.2",
-        "cookie-parser": "1.4.3",
-        "express-session": "1.14.0",
-        "serve-static": "1.11.1",
-        "ws": "1.1.1",
-        "infusion": "2.0.0-dev.20160519T222603Z.754d2c6",
-        "jsonlint": "1.6.0",
-        "resolve": "1.1.6",
-        "node-uuid": "1.4.7",
-        "path-to-regexp": "1.5.3",
-        "json5": "0.5.0"
-    },
-    "devDependencies": {
-        "fluid-grunt-eslint": "18.1.2",
-        "eslint-config-fluid": "1.0.0",
-        "gpii-express": "git://github.com/GPII/gpii-express#58a2f3fc1699a4e14735673d3c43edde7b705666",
-        "gpii-pouchdb": "git://github.com/GPII/gpii-pouchdb#a6a3322fdf059b8a1109f0763454b3f7d8839105",
-        "grunt": "1.0.1",
-        "grunt-jsonlint": "1.0.4",
-        "fluid-grunt-json5lint": "1.0.0",
-        "grunt-shell": "1.3.0",
-        "node-jqunit": "1.1.4"
-    },
-    "license": "BSD-3-Clause",
-    "keywords": [
-        "infusion",
-        "framework",
-        "application",
-        "fluid",
-        "IoC",
-        "express",
-        "Inversion of Control",
-        "MVC",
-        "evented"
-    ],
-    "repository": {
-        "type": "git",
-        "url": "https://github.com/fluid-project/kettle"
-    },
-    "main": "./kettle.js",
-    "engines": {
-        "node": ">=4.2.1"
-    }
+  "name": "kettle",
+  "description": "Declarative IoC-based framework for HTTP and WebSockets servers on node.js based on express and ws",
+  "version": "1.2.1",
+  "author": {
+    "name": "The Fluid Project"
+  },
+  "bugs": {
+    "url": "http://issues.fluidproject.org/browse/KETTLE"
+  },
+  "scripts": {
+    "test": "node tests/all-tests.js"
+  },
+  "homepage": "http://wiki.fluidproject.org/display/fluid/Kettle",
+  "dependencies": {
+    "body-parser": "1.15.2",
+    "cookie-parser": "1.4.3",
+    "express": "4.14.0",
+    "express-session": "1.14.0",
+    "infusion": "2.0.0-dev.20160519T222603Z.754d2c6",
+    "json5": "0.5.0",
+    "jsonlint": "1.6.0",
+    "path-to-regexp": "1.5.3",
+    "resolve": "1.1.6",
+    "serve-static": "1.11.1",
+    "uuid": "^3.0.0",
+    "ws": "1.1.1"
+  },
+  "devDependencies": {
+    "fluid-grunt-eslint": "18.1.2",
+    "eslint-config-fluid": "1.0.0",
+    "gpii-express": "git://github.com/GPII/gpii-express#58a2f3fc1699a4e14735673d3c43edde7b705666",
+    "gpii-pouchdb": "git://github.com/GPII/gpii-pouchdb#a6a3322fdf059b8a1109f0763454b3f7d8839105",
+    "grunt": "1.0.1",
+    "grunt-jsonlint": "1.0.4",
+    "fluid-grunt-json5lint": "1.0.0",
+    "grunt-shell": "1.3.0",
+    "node-jqunit": "1.1.4"
+  },
+  "license": "BSD-3-Clause",
+  "keywords": [
+    "infusion",
+    "framework",
+    "application",
+    "fluid",
+    "IoC",
+    "express",
+    "Inversion of Control",
+    "MVC",
+    "evented"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/fluid-project/kettle"
+  },
+  "main": "./kettle.js",
+  "engines": {
+    "node": ">=4.2.1"
+  }
 }


### PR DESCRIPTION
## Version 3.0.0 of [uuid](https://github.com/kelektiv/node-uuid) just got published.

Hi there,

This week a new version of the [uuid](https://github.com/kelektiv/node-uuid) module got released. The old module which was available by the name [node-uuid](https://www.npmjs.com/package/node-uuid) got deprecated and will show error message upon every install of the module.

To get rid of those install errors I've created this **automated pull request**. I've run some checks against your code base to test whether you're using one of the [deprecated apis](https://github.com/kelektiv/node-uuid/commit/5ae7287fc935eb55ef39133e4be17ef623ca000e), but this isn't the case.


Please test the changes against your code. I didn't run any tests and therefore can't guarantee that it isn't breaking. You can also just close this pr if you don't want to update your module.

In case there's already another pr open to upgrade uuid, I'm sorry for the effort I'm causing.