### PR TITLE
KETTLE-51: Fix the calculation of "content-length" within kettle.dataSource.URL

### DIFF
--- a/lib/dataSource-url.js
+++ b/lib/dataSource-url.js
@@ -210,12 +210,14 @@ kettle.dataSource.URL.handle.http = function (that, baseOptions, data) {
         port: 80,
         method: "GET"
     };
-    if (baseOptions.operation === "set") {
-        data = new Buffer(data);
 
+    var dataBuffer;
+
+    if (baseOptions.operation === "set") {
+        dataBuffer = new Buffer(data);
         defaultOptions.headers = {
             "Content-Type": that.encoding.options.contentType,
-            "Content-Length": data.length
+            "Content-Length": dataBuffer.length
         };
         defaultOptions.method = baseOptions.writeMethod;
     }
@@ -235,6 +237,6 @@ kettle.dataSource.URL.handle.http = function (that, baseOptions, data) {
         fluid.fail("kettle.dataSource.URL cannot handle unknown protocol "  + requestOptions.protocol);
     }
     req.on("error", kettle.wrapCallback(kettle.dataSource.URL.errorCallback(promise, whileMsg)));
-    req.end(data);
+    req.end(dataBuffer ? dataBuffer : data);
     return promise;
 };

--- a/lib/dataSource-url.js
+++ b/lib/dataSource-url.js
@@ -211,6 +211,8 @@ kettle.dataSource.URL.handle.http = function (that, baseOptions, data) {
         method: "GET"
     };
     if (baseOptions.operation === "set") {
+        data = new Buffer(data);
+
         defaultOptions.headers = {
             "Content-Type": that.encoding.options.contentType,
             "Content-Length": data.length

--- a/tests/DataSourcePouchDBTests.js
+++ b/tests/DataSourcePouchDBTests.js
@@ -45,10 +45,12 @@ fluid.defaults("kettle.tests.dataSource.pouchDB.write.environment", {
     }
 });
 
-kettle.tests.dataSource.testURLSetResponse = function (that, dataSource, directModel, dataSourceModel) {
+kettle.tests.dataSource.testURLSetResponse = function (that, dataSource, directModel, dataSourceModel, assertFunc) {
+    assertFunc = assertFunc ? assertFunc : "assertDeepEq";
+
     var reread = dataSource.get(directModel);
     reread.then(function (response) {
-        jqUnit.assertDeepEq("Reread expected response from dataSource", dataSourceModel, response);
+        jqUnit[assertFunc]("Reread expected response from dataSource", dataSourceModel, response);
         that.events.onVerify.fire();
     }, function (error) {
         jqUnit.fail("Failed to reread dataSource response: " + error);
@@ -179,7 +181,6 @@ fluid.defaults("kettle.tests.dataSource.16.CouchDB.URL.set.specialChars", {
         dataSource: {
             type: "kettle.dataSource.URL",
             options: {
-                gradeNames: "kettle.dataSource.CouchDB",
                 url: "http://localhost:6789/testFile/nonexistent_id_for_specialChar",
                 writable: true
             }
@@ -188,7 +189,7 @@ fluid.defaults("kettle.tests.dataSource.16.CouchDB.URL.set.specialChars", {
     invokers: {
         responseFunc: {
             funcName: "kettle.tests.dataSource.testURLSetResponse",
-            args: ["{testEnvironment}", "{testEnvironment}.dataSource", "{testEnvironment}.options.directModel", "{testEnvironment}.options.dataSourceModel"]
+            args: ["{testEnvironment}", "{testEnvironment}.dataSource", "{testEnvironment}.options.directModel", "{testEnvironment}.options.dataSourceModel", "assertLeftHand"]
         }
     }
 });

--- a/tests/DataSourcePouchDBTests.js
+++ b/tests/DataSourcePouchDBTests.js
@@ -45,12 +45,10 @@ fluid.defaults("kettle.tests.dataSource.pouchDB.write.environment", {
     }
 });
 
-kettle.tests.dataSource.testURLSetResponse = function (that, dataSource, directModel, dataSourceModel, assertFunc) {
-    assertFunc = assertFunc ? assertFunc : "assertDeepEq";
-
+kettle.tests.dataSource.testURLSetResponse = function (that, dataSource, directModel, dataSourceModel) {
     var reread = dataSource.get(directModel);
     reread.then(function (response) {
-        jqUnit[assertFunc]("Reread expected response from dataSource", dataSourceModel, response);
+        jqUnit.assertDeepEq("Reread expected response from dataSource", dataSourceModel, response);
         that.events.onVerify.fire();
     }, function (error) {
         jqUnit.fail("Failed to reread dataSource response: " + error);
@@ -170,35 +168,10 @@ fluid.defaults("kettle.tests.dataSource.15.CouchDB.URL.set.existing", {
     }
 });
 
-fluid.defaults("kettle.tests.dataSource.16.CouchDB.URL.set.specialChars", {
-    gradeNames: "kettle.tests.dataSource.pouchDB.write.environment",
-    name: "14. Testing CouchDB URL datasource with HTTP - set with data containing special characters",
-    dataSourceMethod: "set",
-    dataSourceModel: {
-        test: "Gerät"
-    },
-    components: {
-        dataSource: {
-            type: "kettle.dataSource.URL",
-            options: {
-                url: "http://localhost:6789/testFile/nonexistent_id_for_specialChar",
-                writable: true
-            }
-        }
-    },
-    invokers: {
-        responseFunc: {
-            funcName: "kettle.tests.dataSource.testURLSetResponse",
-            args: ["{testEnvironment}", "{testEnvironment}.dataSource", "{testEnvironment}.options.directModel", "{testEnvironment}.options.dataSourceModel", "assertLeftHand"]
-        }
-    }
-});
-
 fluid.test.runTests([
     "kettle.tests.dataSource.3.CouchDB.URL.standard",
     "kettle.tests.dataSource.5.CouchDB.URL.missing",
     "kettle.tests.dataSource.5a.CouchDB.URL.missing",
     "kettle.tests.dataSource.14.CouchDB.URL.set",
-    "kettle.tests.dataSource.15.CouchDB.URL.set.existing",
-    "kettle.tests.dataSource.16.CouchDB.URL.set.specialChars"
+    "kettle.tests.dataSource.15.CouchDB.URL.set.existing"
 ]);

--- a/tests/DataSourcePouchDBTests.js
+++ b/tests/DataSourcePouchDBTests.js
@@ -168,10 +168,36 @@ fluid.defaults("kettle.tests.dataSource.15.CouchDB.URL.set.existing", {
     }
 });
 
+fluid.defaults("kettle.tests.dataSource.16.CouchDB.URL.set.specialChars", {
+    gradeNames: "kettle.tests.dataSource.pouchDB.write.environment",
+    name: "14. Testing CouchDB URL datasource with HTTP - set with data containing special characters",
+    dataSourceMethod: "set",
+    dataSourceModel: {
+        test: "Gerät"
+    },
+    components: {
+        dataSource: {
+            type: "kettle.dataSource.URL",
+            options: {
+                gradeNames: "kettle.dataSource.CouchDB",
+                url: "http://localhost:6789/testFile/nonexistent_id_for_specialChar",
+                writable: true
+            }
+        }
+    },
+    invokers: {
+        responseFunc: {
+            funcName: "kettle.tests.dataSource.testURLSetResponse",
+            args: ["{testEnvironment}", "{testEnvironment}.dataSource", "{testEnvironment}.options.directModel", "{testEnvironment}.options.dataSourceModel"]
+        }
+    }
+});
+
 fluid.test.runTests([
     "kettle.tests.dataSource.3.CouchDB.URL.standard",
     "kettle.tests.dataSource.5.CouchDB.URL.missing",
     "kettle.tests.dataSource.5a.CouchDB.URL.missing",
     "kettle.tests.dataSource.14.CouchDB.URL.set",
-    "kettle.tests.dataSource.15.CouchDB.URL.set.existing"
+    "kettle.tests.dataSource.15.CouchDB.URL.set.existing",
+    "kettle.tests.dataSource.16.CouchDB.URL.set.specialChars"
 ]);

--- a/tests/DataSourceURLTests.js
+++ b/tests/DataSourceURLTests.js
@@ -141,11 +141,46 @@ fluid.defaults("kettle.tests.dataSouce.URL.notFound", {
     }
 });
 
+fluid.defaults("kettle.tests.dataSource.URL.set.specialChars", {
+    gradeNames: ["kettle.tests.singleRequest.config", "kettle.tests.simpleDataSourceTest"],
+    name: "HTTPS dataSource set with special chars test",
+    expect: 1, // for assertion inside HTTPMethods put handler
+    distributeOptions: {
+        handlerType: {
+            target: "{that kettle.app}.options.requestHandlers.testHandler.type",
+            record: "kettle.tests.HTTPMethods.put.handler"
+        },
+        handlerMethod: {
+            target: "{that kettle.app}.options.requestHandlers.testHandler.method",
+            record: "put"
+        }
+    },
+    dataSourceMethod: "set",
+    dataSourceModel: {
+        test: "Gerät"
+    },
+    components: {
+        dataSource: {
+            type: "kettle.dataSource.URL",
+            options: {
+                url: "http://localhost:8081/",
+                writable: true
+            }
+        }
+    },
+    invokers: {
+        responseFunc: {
+            funcName: "jqUnit.assertDeepEq",
+            args: ["The data with special chars is successfully received", "{that}.options.dataSourceModel", "{arguments}.0"]
+        }
+    }
+});
 
 fluid.test.runTests([
 // Attempt to test HTTPS datasource - server currently just hangs without passing on request
     "kettle.tests.dataSource.https",
     "kettle.tests.dataSource.URL.hangup",
     "kettle.tests.dataSouce.CouchDB.hangup",
-    "kettle.tests.dataSouce.URL.notFound"
+    "kettle.tests.dataSouce.URL.notFound",
+    "kettle.tests.dataSource.URL.set.specialChars"
 ]);


### PR DESCRIPTION
When using kettle.dataSource.URL.writable() to send http requests, convert data using "data = new Buffer(data);" in order to calculate the correct content length in bytes. This fixes the error when the posted data contains special character(s) such as "ä".

https://issues.fluidproject.org/browse/KETTLE-51