### PR TITLE
NOJIRA: add kettle.server.ws gradeName to websocket example

### DIFF
--- a/docs/RequestHandlersAndApps.md
+++ b/docs/RequestHandlersAndApps.md
@@ -295,6 +295,7 @@ fluid.defaults("examples.webSocketsConfig", {
         server: {
             type: "kettle.server",
             options: {
+                gradeNames: ["kettle.server.ws"],
                 port: 8081,
                 components: {
                     app: {


### PR DESCRIPTION
While experimenting this morning with writing a WS-based Kettle app, I noticed a small but crucial problem in the "Example mini-application hosting a WebSockets endpoint" in the documentation, which is that it doesn't include the necessary `kettle.server.ws` gradeName as part of the options of the`server` . 

This corrects that, to save some time of the next person trying to work upward from that example. :)