### PR TITLE
KETTLE-70 - Add g++ as dependency

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -3,7 +3,7 @@ env:
 
 steps:
   - name: Tests
-    command: apk add --no-cache --no-progress python make gcc git && npm install && npm test
+    command: apk add --no-cache --no-progress python make gcc g++ git && npm install && npm test
     timeout_in_minutes: 5
     plugins:
       docker:


### PR DESCRIPTION
This didn't seem necessary with older version of the node:8-alpine image but I'm assuming the packaging has been reorg'ed with the new Alpine Linux release and we need to be explicit about g++.