### PR TITLE
KETTLE-72: move form-data from devDependencies to dependencies.

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
         "fluid-resolve": "1.3.0",
         "path-to-regexp": "1.7.0",
         "multer": "1.3.1",
+        "form-data": "2.3.2",
         "json5": "1.0.1"
     },
     "devDependencies": {
@@ -36,7 +37,6 @@
         "nyc": "12.0.2",
         "grunt-shell": "2.1.0",
         "node-jqunit": "1.1.8",
-        "form-data": "2.3.2",
         "rimraf": "2.6.2"
     },
     "license": "BSD-3-Clause",


### PR DESCRIPTION
Addresses the issue raised by @the-t-in-rtf in https://issues.fluidproject.org/browse/KETTLE-72 - since `kettle.loadTestingSupport()` is used in testing contexts outside of Kettle itself, all dependencies for it need to be in `dependencies`.