### PR TITLE
Unbreak table describing loadConfig parameters

### DIFF
--- a/History.md
+++ b/History.md
@@ -1,5 +1,11 @@
 # Version History
 
+## 1.12.0 / 2020-04-10
+
+* KETTLE-82: Fix for client abort causing server exit
+* Updates for compatibility with FLUID-6148/FLUID-6145 branches of Infusion
+* General dependency update
+
 ## 1.11.1 / 2019-05-23
 
 * Reorganisation of request launching logic to permit use under post-FLUID-6148 branches of Infusion

--- a/docs/ConfigsAndApplications.md
+++ b/docs/ConfigsAndApplications.md
@@ -102,12 +102,29 @@ Kettle includes a driver function, `kettle.config.loadConfig` which will load an
 JSON or JSON5 file in the filesystem. It accepts an `options` structure which includes the
 following fields:
 
-|Member name| Type | Description |
-|-----------|------|-------------|
-|`configName`| `String` | The name of the config (the bare filename, minus any extension) which is to be loaded|
-|`configPath`| `String` | The directory holding the config. This path may start with a symbolic module reference, e.g.
-of the form `%kettle`, to a module which has been registered using Infusion's module API
-[`fluid.module.register`](http://docs.fluidproject.org/infusion/development/NodeAPI.html#fluid-module-register-name-basedir-modulerequire-)|
+<table>
+    <thead>
+        <tr style="white-space: nowrap;">
+            <th>Member name</th>
+            <th>Type</th>
+            <th>Description</th>
+        </tr>
+    </thead>
+    <tbody>
+        <tr>
+            <td><code>configName</code></td>
+            <td><code>String</code></td>
+            <td>The name of the config (the bare filename, minus any extension) which is to be loaded</td>
+        </tr>
+        <tr>
+            <td><code>configPath</code></td>
+            <td><code>String</code></td>
+            <td>The directory holding the config. This path may start with a symbolic module reference, e.g. 
+                of the form `%kettle`, to a module which has been registered using Infusion's module API 
+                [`fluid.module.register`](http://docs.fluidproject.org/infusion/development/NodeAPI.html#fluid-module-register-name-basedir-modulerequire-)</td>
+        </tr>
+    </tbody>
+</table>
 
 `kettle.config.loadConfig` will return the (Infusion) component instance of the initialised application. You could use
 this, for example, to terminate the application using its ``destroy()`` method.

--- a/docs/ConfigsAndApplications.md
+++ b/docs/ConfigsAndApplications.md
@@ -119,8 +119,8 @@ following fields:
         <tr>
             <td><code>configPath</code></td>
             <td><code>String</code></td>
-            <td>The directory holding the config. This path may start with a symbolic module reference, e.g. 
-                of the form `%kettle`, to a module which has been registered using Infusion's module API 
+            <td>The directory holding the config. This path may start with a symbolic module reference, e.g.
+                of the form `%kettle`, to a module which has been registered using Infusion's module API
                 [`fluid.module.register`](http://docs.fluidproject.org/infusion/development/NodeAPI.html#fluid-module-register-name-basedir-modulerequire-)</td>
         </tr>
     </tbody>

--- a/docs/RequestHandlersAndApps.md
+++ b/docs/RequestHandlersAndApps.md
@@ -77,8 +77,9 @@ multiple apps are merged together from different sources to produce combined app
             <code>request.req.url</code>. The entire incoming URL will remain visible in
             <code>request.req.originalUrl</code> –
             this is the same behaviour as express.js <a href="http://expressjs.com/api.html#app.use">routing system</a>.
-            It is primarily useful when using <a href="./Middleware.md#built-in-standard-middleware-bundled-with-kettle">static middleware</a> which will compare the
-            <code>req.url</code> value with the filesystem path relative to its mount point.
+            It is primarily useful when using 
+            <a href="./Middleware.md#built-in-standard-middleware-bundled-with-kettle">static middleware</a> 
+            which will compare the <code>req.url</code> value with the filesystem path relative to its mount point.
         </tr>
         <tr>
             <td><code>method</code> (optional)</td>

--- a/docs/RequestHandlersAndApps.md
+++ b/docs/RequestHandlersAndApps.md
@@ -77,8 +77,8 @@ multiple apps are merged together from different sources to produce combined app
             <code>request.req.url</code>. The entire incoming URL will remain visible in
             <code>request.req.originalUrl</code> –
             this is the same behaviour as express.js <a href="http://expressjs.com/api.html#app.use">routing system</a>.
-            It is primarily useful when using 
-            <a href="./Middleware.md#built-in-standard-middleware-bundled-with-kettle">static middleware</a> 
+            It is primarily useful when using
+            <a href="./Middleware.md#built-in-standard-middleware-bundled-with-kettle">static middleware</a>
             which will compare the <code>req.url</code> value with the filesystem path relative to its mount point.
         </tr>
         <tr>


### PR DESCRIPTION
In short-form markdown tables, line breaks are interpreted as starting a new cell row, so each row must be written in one line of text.
For tables with longer content, it seems like the full HTML form is more appropriate.