### PR TITLE
Kettle 86: Add backward-compatible API for sending response metadata

### DIFF
--- a/lib/KettleRequest.js
+++ b/lib/KettleRequest.js
@@ -164,9 +164,9 @@ fluid.defaults("kettle.request", {
         /* Construct a "promisified" proxy for the handling of this request. It will
          * have handlers registered which forward to this request's success and error events.
          * The promise may be rejected or resolved by the user to represent that disposition
-         * for the overall request. 
+         * for the overall request.
          * handlerPromise is a legacy version of the proxy that is resolved directly with a
-         *  response body, whereas the newer outerHandlerPromise expects an object 
+         *  response body, whereas the newer outerHandlerPromise expects an object
          * containing a responseBody value and an optional responseOptions value.
          * TODO: on next breaking framework update, remove the legacy handlerPromise.
          *  */
@@ -311,7 +311,7 @@ kettle.request.sequenceRequest = function (fullSequence, request) {
     // FIXME: this is a very odd block of code. It looks like the below then is essentially a no-op
     //        it requires a closer look once we're into straight refactoring.
     //        This function is only called in kettle.request.initiateHandleRequest,
-    //        so if it is really simpler than it is currently, it should probably just 
+    //        so if it is really simpler than it is currently, it should probably just
     //        be inlined there.
     sequence.then(function () { // only the handler's promise return counts for success resolution
         fluid.promise.follow(request.outerHandlerPromise, togo);

--- a/lib/KettleRequest.js
+++ b/lib/KettleRequest.js
@@ -433,14 +433,14 @@ kettle.request.http.successHandler = function (request, responseBody, responseOp
         request.res.set(field, headers[field]);
     }
 
-    var responseBodyType = typeof(responseBody);
-    if (responseBodyType === "object" || responseBodyType === "number") {
-        request.res.json(responseBody);
-    } else if (responseBodyType === "string") {
+    if (typeof (responseBody) === "string") {
         request.res.send(responseBody);
-    } else {
+    } else if (responseBody === undefined) {
         request.res.end();
+    } else {
+        request.res.json(responseBody);
     }
+
 };
 
 /**

--- a/lib/KettleRequest.js
+++ b/lib/KettleRequest.js
@@ -433,9 +433,10 @@ kettle.request.http.successHandler = function (request, responseBody, responseOp
         request.res.set(field, headers[field]);
     }
 
-    if (typeof(responseBody) === "object") {
+    var responseBodyType = typeof(responseBody);
+    if (responseBodyType === "object" || responseBodyType === "number") {
         request.res.json(responseBody);
-    } else if (typeof(responseBody) === "string") {
+    } else if (responseBodyType === "string") {
         request.res.send(responseBody);
     } else {
         request.res.end();

--- a/lib/KettleRequest.js
+++ b/lib/KettleRequest.js
@@ -147,8 +147,8 @@ fluid.defaults("kettle.request", {
     },
     events: {
         onHandle: null,  // Fired in order to execute its listener, handleRequest, which invokes the user's handler
-        onSuccess: null, // A convenient proxy for the main request handler to report disposition (equivalent to handlerPromise)
-        onError: null,  // A convenient proxy for the main request handler to report disposition (equivalent to handlerPromise)
+        onSuccess: null, // A convenient proxy for the main request handler to report disposition (equivalent to outerHandlerPromise)
+        onError: null,  // A convenient proxy for the main request handler to report disposition (equivalent to outerHandlerPromise)
         onRequestEnd: null,
         onRequestSuccess: null, // Overall disposition of the entire request - handler actually sends response
         onRequestError: null // Overall disposition of the entire request - handler actually sends response
@@ -165,12 +165,21 @@ fluid.defaults("kettle.request", {
          * have handlers registered which forward to this request's success and error events.
          * The promise may be rejected or resolved by the user to represent that disposition
          * for the overall request */
-        handlerPromise: "@expand:fluid.promise()"
+        handlerPromise: "@expand:fluid.promise()",
+        /*
+         * TODO: explain what the heck outerHandlePromise is for.
+         * (It's a backward compatibility courtesy for enabling sending additional metadata with response payloads, such as status codes)
+         */
+        outerHandlerPromise: "@expand:fluid.promise()"
     },
     listeners: {
         "onCreate.activate": {
             funcName: "kettle.request.activate",
             priority: "first"
+        },
+        "onCreate.forwardOuterHandlerPromise": {
+            funcName: "kettle.request.forwardOuterHandlerPromise",
+            args: ["{that}.handlerPromise", "{that}.outerHandlerPromise"]
         },
         "onCreate.handle": {
             funcName: "kettle.request.initiateHandleRequest",
@@ -181,16 +190,16 @@ fluid.defaults("kettle.request", {
             funcName: "kettle.request.handleRequest",
             args: "{that}"
         },
-        "onSuccess.forward": "kettle.request.forwardPromise(resolve, {that}.handlerPromise, {arguments}.0)",
-        "onError.forward": "kettle.request.forwardPromise(reject, {that}.handlerPromise, {arguments}.0)"
+        "onSuccess.forward": "kettle.request.forwardPromise(resolve, {that}.outerHandlerPromise,  {arguments}.0, {arguments}.1)",
+        "onError.forward": "kettle.request.forwardPromise(reject, {that}.outerHandlerPromise, {arguments}.0)"
     }
 });
 
 // A handler which reports a 404 if the request has not already been handled (e.g. by some middleware, e.g. static)
 kettle.request.notFoundHandler = function (request) {
     /* istanbul ignore else - much middleware is naughty and does not call "next" if it thinks it has fully handled the request */
-    if (!request.handlerPromise.disposition) {
-        request.handlerPromise.reject({statusCode: 404, message: "Cannot " + request.req.method + " " + request.req.originalUrl});
+    if (!request.outerHandlerPromise.disposition) {
+        request.outerHandlerPromise.reject({statusCode: 404, message: "Cannot " + request.req.method + " " + request.req.originalUrl});
     }
 };
 
@@ -200,14 +209,22 @@ kettle.request.notFoundHandler = function (request) {
  * handled since there will be no active request by which to report it, so the failure will simply be logged.
  * @param {String} method - The promise method to be invoked
  * @param {Promise} promise - The promise on which the method is to be invoked
- * @param {Any} val - The payload to be sent to the method
+ * @param {Any} value - The payload to be sent to the method. A response body when method is "resolve" and an error payload when method is "reject"
+ * @param {Any} [responseOptions] - Optional additional metadata for the response, e.g. statusCode. Is only supplied when method is "resolve".
  */
-kettle.request.forwardPromise = function (method, promise, val) {
+kettle.request.forwardPromise = function (method, promise, value, responseOptions) {
     if (!promise.disposition) {
-        promise[method](val);
+        if (method === "resolve") {
+            promise.resolve({
+                responseBody: value,
+                responseOptions: responseOptions
+            });
+        } else if (method === "reject") {
+            promise.reject(value);
+        }
     } else {
         // Don't use fluid.fail here to avoid infinite triggering of errors
-        fluid.log("Error in forwarding result ", val, " to promise " + method + ": promise has already received " + promise.disposition);
+        fluid.log("Error in forwarding result ", value, " to promise " + method + ": promise has already received " + promise.disposition);
     }
 };
 
@@ -226,6 +243,17 @@ kettle.request.clear = function () {
     kettle.markActiveRequest(null);
 };
 
+/**
+ * Convert any resolutions of handlerPromise to resolutions of outerHandlerPromise.
+ * @param {Promise} handlerPromise the request's handlerPromise, which uses the legacy API of resolving with the requestBody as the only parameter
+ * @param {Promise} outerHandlerPromise a replacement for handlerPromise implementing a new API that accepts an additional parameter specifying request options such as status codes
+ */
+kettle.request.forwardOuterHandlerPromise = function (handlerPromise, outerHandlerPromise) {
+    handlerPromise.then(function (requestBody) {
+        kettle.request.forwardPromise("resolve", outerHandlerPromise, requestBody);
+    }, outerHandlerPromise.reject);
+};
+
 /** Kick off the user's `handleRequest' invoker, and convert any exception thrown from it into a rejection, unless
  * the request has already been handled through some other cause. Given the request is definitely handled by the end
  * of this invocation, finally, unmark the request as active
@@ -235,8 +263,8 @@ kettle.request.handleRequest = function (that) {
     try {
         that.handleRequest(that);
     } catch (err) {
-        if (!that.handlerPromise.disposition) {
-            that.handlerPromise.reject({message: err.message, stack: err.stack});
+        if (!that.outerHandlerPromise.disposition) {
+            that.outerHandlerPromise.reject({message: err.message, stack: err.stack});
         }
     } finally {
         kettle.markActiveRequest(null);
@@ -254,7 +282,7 @@ kettle.request.handleRequestTask = function (request) {
     if (!request.res.finished) { // don't handle if some middleware has already sent a full response - makes us deterministic on node 4
         request.events.onHandle.fire(request); // our actual request handler triggerer
     }
-    return request.handlerPromise;
+    return request.outerHandlerPromise;
 };
 
 /**
@@ -269,7 +297,7 @@ kettle.request.handleRequestTask = function (request) {
  */
 
 /** Given the full sequence of request handling tasks, construct a single promise which sequences them. The yielded
- * promise will only resolve if the request's `handlerPromise` has resolved.
+ * promise will only resolve if the request's `outerHandlerPromise` has resolved.
  * @param {requestTask[]} fullSequence - An array of request tasks to be sequenced.
  * @param {kettle.request} request - The request for which the sequence is being orchestrated
  * @return {Promise} A promise guiding the disposition of the overall request, which will be dispatched to
@@ -278,8 +306,13 @@ kettle.request.handleRequestTask = function (request) {
 kettle.request.sequenceRequest = function (fullSequence, request) {
     var sequence = fluid.promise.sequence(fullSequence, request);
     var togo = fluid.promise();
+    // FIXME: this is a very odd block of code. It looks like the below then is essentially a no-op
+    //        it requires a closer look once we're into straight refactoring.
     sequence.then(function () { // only the handler's promise return counts for success resolution
-        fluid.promise.follow(request.handlerPromise, togo);
+        // TODO: Wrap handlerPromise in a new promise with a fork,
+        // The new promise will follow the old promise, but in the case of success, it will cascade to resolve a new promise with a variant signature.
+        // then call fluid.promise.follow on the newly produced promise
+        fluid.promise.follow(request.outerHandlerPromise, togo);
     }, togo.reject);
     return togo;
 };
@@ -295,6 +328,8 @@ kettle.request.initiateHandleRequest = function (request, rootSequence) {
     fluid.log("Kettle server allocated request object with type ", request.typeName);
     var requestSequence = kettle.middleware.getHandlerSequence(request, "requestMiddleware");
     var fullSequence = rootSequence.concat(requestSequence).concat([kettle.request.handleRequestTask]);
+    // FIXME: we *think* the below line could just be replaced with
+    // fluid.promise.sequence(fullSequence, request);
     var handleRequestPromise = kettle.request.sequenceRequest(fullSequence, request);
     request.handleFullRequest(request, handleRequestPromise, request.next);
     handleRequestPromise.then(kettle.request.clear, kettle.request.clear);
@@ -327,7 +362,7 @@ fluid.defaults("kettle.request.http", {
         },
         "onRequestSuccess.handle": {
             funcName: "kettle.request.http.successHandler",
-            args: ["{that}", "{arguments}.0"]
+            args: ["{that}", "{arguments}.0", "{arguments}.1"]
         }
     }
 });
@@ -349,8 +384,9 @@ fluid.defaults("kettle.request.http.mismatch", {
  * @param {Function} next - The `next` disposition function handed to us by the overall container, e.g. express
  */
 kettle.request.http.handleFullRequest = function (request, fullRequestPromise, next) {
-    fullRequestPromise.then(function (response) {
-        request.events.onRequestSuccess.fire(response);
+    fullRequestPromise.then(function (payload) {
+        payload = payload || {};
+        request.events.onRequestSuccess.fire(payload.responseBody, payload.responseOptions);
         next();
     }, function (err) {
         request.events.onRequestError.fire(err);
@@ -381,17 +417,26 @@ kettle.request.http.errorHandler = function (res, error) {
 /**
  * Send a successful payload to the client if the success event is fired
  * @param {Component} request - A kettle.request component
- * @param {Object} response A success payload
+ * @param {Object} responseBody The payload of a success response
+ * @param {Number} responseOptions Additional metadata for the response, e.g. statusCode
  */
-kettle.request.http.successHandler = function (request, response) {
+kettle.request.http.successHandler = function (request, responseBody, responseOptions) {
+    // Extract response options to be applied to the request
+    // TODO: do we want to react to other keys besides statusCode? mimeType, headers?
+
+    // The default status code for a successful HTTP response is 200 OK
+    var statusCode = responseOptions && responseOptions.statusCode || 200;
+    // var headers = responseOptions && responseOptions.headers || {};
+
     if (request.req.method.toLowerCase() === "options") {
-        request.res.status(200).end();
+        request.res.status(statusCode !== undefined ? statusCode : statusCode).end();
         return;
     }
-    if (typeof(response) !== "string") {
-        request.res.json(response);
+    request.res.status(statusCode);
+    if (typeof(responseBody) !== "string") {
+        request.res.json(responseBody);
     } else {
-        request.res.status(200).send(response);
+        request.res.send(responseBody);
     }
 };
 

--- a/lib/KettleRequest.js
+++ b/lib/KettleRequest.js
@@ -433,9 +433,9 @@ kettle.request.http.successHandler = function (request, responseBody, responseOp
         request.res.set(field, headers[field]);
     }
 
-    if (typeof(responseBody) !== "string") {
+    if (typeof(responseBody) === "object") {
         request.res.json(responseBody);
-    } else if (responseBody !== undefined) {
+    } else if (typeof(responseBody) === "string") {
         request.res.send(responseBody);
     } else {
         request.res.end();

--- a/lib/KettleRequest.js
+++ b/lib/KettleRequest.js
@@ -331,7 +331,7 @@ kettle.request.initiateHandleRequest = function (request, rootSequence) {
     var requestSequence = kettle.middleware.getHandlerSequence(request, "requestMiddleware");
     var fullSequence = rootSequence.concat(requestSequence).concat([kettle.request.handleRequestTask]);
     // FIXME: we *think* the below line could just be replaced with
-    // var handleRequestPromise = fluid.promise.sequence(fullSequence, request);
+    // fluid.promise.sequence(fullSequence, request);
     var handleRequestPromise = kettle.request.sequenceRequest(fullSequence, request);
     request.handleFullRequest(request, handleRequestPromise, request.next);
     handleRequestPromise.then(kettle.request.clear, kettle.request.clear);
@@ -433,15 +433,12 @@ kettle.request.http.successHandler = function (request, responseBody, responseOp
         request.res.set(field, headers[field]);
     }
 
-    if (request.req.method.toLowerCase() === "options") {
-        request.res.end();
-        return;
-    }
-
     if (typeof(responseBody) !== "string") {
         request.res.json(responseBody);
-    } else {
+    } else if (responseBody !== undefined) {
         request.res.send(responseBody);
+    } else {
+        request.res.end();
     }
 };
 

--- a/lib/KettleRequest.js
+++ b/lib/KettleRequest.js
@@ -164,12 +164,14 @@ fluid.defaults("kettle.request", {
         /* Construct a "promisified" proxy for the handling of this request. It will
          * have handlers registered which forward to this request's success and error events.
          * The promise may be rejected or resolved by the user to represent that disposition
-         * for the overall request */
+         * for the overall request. 
+         * handlerPromise is a legacy version of the proxy that is resolved directly with a
+         *  response body, whereas the newer outerHandlerPromise expects an object 
+         * containing a responseBody value and an optional responseOptions value.
+         * TODO: on next breaking framework update, remove the legacy handlerPromise.
+         *  */
         handlerPromise: "@expand:fluid.promise()",
-        /*
-         * TODO: explain what the heck outerHandlePromise is for.
-         * (It's a backward compatibility courtesy for enabling sending additional metadata with response payloads, such as status codes)
-         */
+        legacyHandlerPromise: "{that}.handlerPromise",
         outerHandlerPromise: "@expand:fluid.promise()"
     },
     listeners: {
@@ -179,7 +181,7 @@ fluid.defaults("kettle.request", {
         },
         "onCreate.forwardOuterHandlerPromise": {
             funcName: "kettle.request.forwardOuterHandlerPromise",
-            args: ["{that}.handlerPromise", "{that}.outerHandlerPromise"]
+            args: ["{that}.legacyHandlerPromise", "{that}.outerHandlerPromise"]
         },
         "onCreate.handle": {
             funcName: "kettle.request.initiateHandleRequest",
@@ -244,13 +246,13 @@ kettle.request.clear = function () {
 };
 
 /**
- * Convert any resolutions of handlerPromise to resolutions of outerHandlerPromise.
- * @param {Promise} handlerPromise the request's handlerPromise, which uses the legacy API of resolving with the requestBody as the only parameter
- * @param {Promise} outerHandlerPromise a replacement for handlerPromise implementing a new API that accepts an additional parameter specifying request options such as status codes
+ * Convert any resolutions of legacyHandlerPromise to resolutions of outerHandlerPromise.
+ * @param {Promise} legacyHandlerPromise the legacy Promise proxy for the request, which is resolved with the responseBody as the only parameter
+ * @param {Promise} outerHandlerPromise the newer Promise proxy, which accepts a an object that specifies both a responseBody and responseOptions
  */
-kettle.request.forwardOuterHandlerPromise = function (handlerPromise, outerHandlerPromise) {
-    handlerPromise.then(function (requestBody) {
-        kettle.request.forwardPromise("resolve", outerHandlerPromise, requestBody);
+kettle.request.forwardOuterHandlerPromise = function (legacyHandlerPromise, outerHandlerPromise) {
+    legacyHandlerPromise.then(function (responseBody) {
+        kettle.request.forwardPromise("resolve", outerHandlerPromise, responseBody);
     }, outerHandlerPromise.reject);
 };
 
@@ -308,10 +310,10 @@ kettle.request.sequenceRequest = function (fullSequence, request) {
     var togo = fluid.promise();
     // FIXME: this is a very odd block of code. It looks like the below then is essentially a no-op
     //        it requires a closer look once we're into straight refactoring.
+    //        This function is only called in kettle.request.initiateHandleRequest,
+    //        so if it is really simpler than it is currently, it should probably just 
+    //        be inlined there.
     sequence.then(function () { // only the handler's promise return counts for success resolution
-        // TODO: Wrap handlerPromise in a new promise with a fork,
-        // The new promise will follow the old promise, but in the case of success, it will cascade to resolve a new promise with a variant signature.
-        // then call fluid.promise.follow on the newly produced promise
         fluid.promise.follow(request.outerHandlerPromise, togo);
     }, togo.reject);
     return togo;
@@ -329,7 +331,7 @@ kettle.request.initiateHandleRequest = function (request, rootSequence) {
     var requestSequence = kettle.middleware.getHandlerSequence(request, "requestMiddleware");
     var fullSequence = rootSequence.concat(requestSequence).concat([kettle.request.handleRequestTask]);
     // FIXME: we *think* the below line could just be replaced with
-    // fluid.promise.sequence(fullSequence, request);
+    // var handleRequestPromise = fluid.promise.sequence(fullSequence, request);
     var handleRequestPromise = kettle.request.sequenceRequest(fullSequence, request);
     request.handleFullRequest(request, handleRequestPromise, request.next);
     handleRequestPromise.then(kettle.request.clear, kettle.request.clear);
@@ -421,18 +423,21 @@ kettle.request.http.errorHandler = function (res, error) {
  * @param {Number} responseOptions Additional metadata for the response, e.g. statusCode
  */
 kettle.request.http.successHandler = function (request, responseBody, responseOptions) {
-    // Extract response options to be applied to the request
-    // TODO: do we want to react to other keys besides statusCode? mimeType, headers?
-
+    // Extract response options and apply them to the request
     // The default status code for a successful HTTP response is 200 OK
     var statusCode = responseOptions && responseOptions.statusCode || 200;
-    // var headers = responseOptions && responseOptions.headers || {};
+    request.res.status(statusCode);
+
+    var headers = responseOptions && responseOptions.headers || {};
+    for (var field in headers) {
+        request.res.set(field, headers[field]);
+    }
 
     if (request.req.method.toLowerCase() === "options") {
-        request.res.status(statusCode !== undefined ? statusCode : statusCode).end();
+        request.res.end();
         return;
     }
-    request.res.status(statusCode);
+
     if (typeof(responseBody) !== "string") {
         request.res.json(responseBody);
     } else {

--- a/tests/GoodRequestTests.js
+++ b/tests/GoodRequestTests.js
@@ -122,6 +122,7 @@ fluid.defaults("kettle.tests.goodRequest.options.config", {
     name: "Good request: options request",
     message: "Received response from successful request with empty parameter",
     expected: undefined,
+    expectedStatusCode: 204,
     distributeOptions: {
         target: "{that testRequest}.options.method",
         record: "OPTIONS"
@@ -138,7 +139,12 @@ fluid.defaults("kettle.tests.goodRequest.options.handler", {
 });
 
 kettle.tests.goodRequest.options.handleRequest = function (request) {
-    request.events.onSuccess.fire({message: "Ignored message"});
+    request.events.onSuccess.fire(undefined, {
+        statusCode: 204,
+        headers: {
+            Allow: "OPTIONS"
+        }
+    });
 };
 
 

--- a/tests/configs/kettle.tests.HTTPMethods.config.json
+++ b/tests/configs/kettle.tests.HTTPMethods.config.json
@@ -26,6 +26,11 @@
                                         "type": "kettle.tests.HTTPMethods.put.handler",
                                         "route": "/",
                                         "method": "put"
+                                    },
+                                    "put201Handler": {
+                                        "type": "kettle.tests.HTTPMethods.put201.handler",
+                                        "route": "/201",
+                                        "method": "put"
                                     }
                                 }
                             }


### PR DESCRIPTION
Pair-programmed with @amb26 .

This modification allows for `kettle.request.http` components to be resolved with response metadata in addition to the response payload, by writing e.g. 
```
request.events.onSuccess.fire(request.req.body, {
    statusCode: 201
});
```

This is in rough working shape, but requires some documentation and refactoring.