### PR TITLE
FLUID-6537 Limit CI workflows to 10 minutes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,8 @@ jobs:
   tests:
     runs-on: ${{ matrix.os }}
 
+    timeout-minutes: 10
+
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macOS-latest]


### PR DESCRIPTION
Sometimes CI jobs will hang for a while and the default timeout in GitHub Actions is 360 minutes. This consumes the total of 2000-3000 minutes/month assigned to our project and should be limited.

Most jobs take between 4-5min to run so proposing we limit them at 10min and increase when needed.